### PR TITLE
Potential fix for code scanning alert no. 3: Missing rate limiting

### DIFF
--- a/anime-gallery-electron/package.json
+++ b/anime-gallery-electron/package.json
@@ -56,7 +56,8 @@
     "is-path-inside": "^4.0.0",
     "lodash": "^4.17.23",
     "systeminformation": "^5.30.3",
-    "uuid": "^13.0.0"
+    "uuid": "^13.0.0",
+    "express-rate-limit": "^8.2.1"
   },
   "devDependencies": {
     "@electron-forge/cli": "^7.11.1",

--- a/anime-gallery-electron/src/server/routes/serving-files.ts
+++ b/anime-gallery-electron/src/server/routes/serving-files.ts
@@ -1,8 +1,16 @@
 import express, { Router } from 'express';
+import rateLimit from 'express-rate-limit';
 import { servePicture } from '../controllers/serve-pictures';
 import { serveVideo } from '../controllers/serve-videos';
 
 const router: Router = express.Router();
+
+const servingFilesLimiter = rateLimit({
+  windowMs: 15 * 60 * 1000, // 15 minutes
+  max: 100, // limit each IP to 100 requests per windowMs for this router
+});
+
+router.use(servingFilesLimiter);
 
 router.get('/picture', servePicture);
 


### PR DESCRIPTION
Potential fix for [https://github.com/peteramir-1/anime-gallary-win-app/security/code-scanning/3](https://github.com/peteramir-1/anime-gallary-win-app/security/code-scanning/3)

In general, the problem should be fixed by introducing rate-limiting middleware for routes that perform expensive operations such as serving files from disk. In an Express-based TypeScript application, a common approach is to use the well-known `express-rate-limit` package and apply a limiter either to all routes on a router or to specific sensitive routes.

For this specific file, the least invasive fix that does not change existing functionality is to import `express-rate-limit`, configure a limiter with reasonable defaults (for example, a certain number of requests per 15-minute window), and apply it to the router via `router.use(limiter);` so that both `/picture` and `/video` are protected. This ensures all the CodeQL variants complaining about missing rate limiting on `serveVideo` (and any similar handlers on this router) are addressed in one place. Concretely, in `anime-gallery-electron/src/server/routes/serving-files.ts`, we should: (1) add an import for `express-rate-limit`, (2) define a `limiter` instance (e.g., `windowMs: 15 * 60 * 1000`, `max: 100`), and (3) call `router.use(limiter);` before the `router.get` definitions. No changes to the controllers are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
